### PR TITLE
Updated Dockerfile

### DIFF
--- a/docker-example/Dockerfile
+++ b/docker-example/Dockerfile
@@ -25,7 +25,8 @@ RUN \
 
     # Copy static files out of /app to save space in backend image
     mv .web/_static /tmp/_static && \
-    rm -rf .web && mkdir .web && \
+    rm -rf .web && \
+    mkdir .web && \
     mv /tmp/_static .web/_static 
 
 # Stage 2: copy artifacts into slim image 
@@ -37,4 +38,4 @@ COPY --chown=nextpy --from=init /app /app
 USER nextpy
 ENV PATH="/app/.venv/bin:$PATH" API_URL=$API_URL
 
-CMD nextpy db migrate && nextpy run --env prod --backend-only
+CMD ["sh","-c","nextpy db migrate && nextpy run --env prod --backend-only"]

--- a/docker-example/Dockerfile
+++ b/docker-example/Dockerfile
@@ -11,21 +11,22 @@ COPY . .
 # Create virtualenv which will be copied into final container
 ENV VIRTUAL_ENV=/app/.venv
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
-RUN python3.11 -m venv $VIRTUAL_ENV
+RUN \
+    python3.11 -m venv $VIRTUAL_ENV && \
 
-# Install app requirements and nextpy inside virtualenv
-RUN pip install -r requirements.txt
+    # Install app requirements and nextpy inside virtualenv
+    pip install --no-cache-dir -r requirements.txt && \
+    
+    # Deploy templates and prepare app
+    nextpy init && \
+    
+    # Export static copy of frontend to /app/.web/_static
+    nextpy export --frontend-only --no-zip && \
 
-# Deploy templates and prepare app
-RUN nextpy init
-
-# Export static copy of frontend to /app/.web/_static
-RUN nextpy export --frontend-only --no-zip
-
-# Copy static files out of /app to save space in backend image
-RUN mv .web/_static /tmp/_static
-RUN rm -rf .web && mkdir .web
-RUN mv /tmp/_static .web/_static
+    # Copy static files out of /app to save space in backend image
+    mv .web/_static /tmp/_static && \
+    rm -rf .web && mkdir .web && \
+    mv /tmp/_static .web/_static 
 
 # Stage 2: copy artifacts into slim image 
 FROM python:3.11-slim


### PR DESCRIPTION
Description: 
* There is a good reason to use --no-cache-dir when you are building Docker images. The cache is usually useless in a Docker  image, and you can definitely shrink the image size by disabling the cache.
* The CMD instruction uses the shell form to execute the command within a shell and is enclosed within sh -c "..." to ensure proper execution of the shell command.